### PR TITLE
Fix basic program example

### DIFF
--- a/content/introduction/index.md
+++ b/content/introduction/index.md
@@ -27,6 +27,8 @@ class Program
 
     static int Main(string[] args)
     {
+        RuntimeManager.DiscoverOrDownloadSuitableQtRuntime();
+        
         using (var app = new QGuiApplication(args))
         {
             using (var engine = new QQmlApplicationEngine())

--- a/content/introduction/index.md
+++ b/content/introduction/index.md
@@ -10,6 +10,11 @@ Qml.Net is a thin layer glueing together two well-established technologies, QtQu
 
 **```Program.cs```**
 ```csharp
+using System;
+using System.IO;
+using Qml.Net;
+using Qml.Net.Runtimes;
+
 class Program
 {
     public class NetObject
@@ -26,7 +31,7 @@ class Program
         {
             using (var engine = new QQmlApplicationEngine())
             {
-                Qml.RegisterType<NetObject>("test", 1, 1);
+                Qml.Net.Qml.RegisterType<NetObject>("test", 1, 1);
 
                 engine.Load("Main.qml");
                 


### PR DESCRIPTION
Using Visual Studio Code the `using` statements don't get auto-added like in VS, and it looks like the `RegisterType` function was moved (maybe?).